### PR TITLE
remove all android 4.4 cookies from webview

### DIFF
--- a/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
+++ b/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
@@ -87,8 +87,19 @@ public class CookieMaster extends CordovaPlugin {
         }
 
         else if (ACTION_CLEAR_COOKIES.equals(action)) {
-            CookieManager.getInstance().removeAllCookie();
-            callbackContext.success();
+
+            CookieManager cookieManager = CookieManager.getInstance();
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+			    cookieManager.removeAllCookies();
+			    cookieManager.flush();
+			} else
+			{
+			    cookieManager.removeAllCookie();
+			    cookieManager.removeSessionCookie();
+			}
+
+			callbackContext.success();
             return true;
         }
 


### PR DESCRIPTION
Android 4.4 has specific API to remove cookie. So I added version check ( < LOLLIPOP_MR1 5.0) to do this job.
