### PR TITLE
Remove Unused Import Breaking Android API 23+

### DIFF
--- a/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
+++ b/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
@@ -9,8 +9,6 @@ import org.json.JSONException;
 
 import android.util.Log;
 
-import org.apache.http.cookie.Cookie;
-
 import java.net.HttpCookie;
 
 import android.webkit.CookieManager;


### PR DESCRIPTION
Importing `org.apache.http.cookie.Cookie` is breaking builds targeting Android API 23+ since [`org.apache.http` was removed](http://stackoverflow.com/q/32180500/477632). Fortunately, this import is unused, so it's a simple fix.